### PR TITLE
Add reorder siblings with Alt+Up/Alt+Down

### DIFF
--- a/README.md
+++ b/README.md
@@ -179,6 +179,7 @@ Full block editing with vim-style modal workflow:
 - `o` to create a new block below
 - `dd` to delete a block
 - `Tab` / `Shift+Tab` to indent/unindent
+- `Alt+Up` / `Alt+Down` to move a block among its siblings
 - Undo with `u`, redo with `Ctrl+R`
 - Auto-pairing for `()`, `[]`, `{}`
 - `{{TODO}}` / `{{DONE}}` toggle with `Alt+Enter` or `Ctrl+Enter`
@@ -252,6 +253,8 @@ Three built-in presets. Set with `keybindings.preset` in config.
 | Edit block | `i` | `Enter` | `Enter` |
 | New block | `o` | `Alt+Enter` | `Ctrl+Enter` |
 | Delete block | `dd` | — | — |
+| Move block up | `Alt+Up` | `Alt+Up` | `Alt+Shift+Up` |
+| Move block down | `Alt+Down` | `Alt+Down` | `Alt+Shift+Down` |
 | Search | `/` | `Ctrl+S` | `Ctrl+Shift+F` |
 | Undo | `u` | `Ctrl+/` | `Ctrl+Z` |
 | Redo | `Ctrl+R` | `Ctrl+Shift+/` | `Ctrl+Shift+Z` |
@@ -322,7 +325,7 @@ What's working now and what's next.
 ### Implemented
 
 - [x] Daily notes with multi-day navigation
-- [x] Block tree editing (create, edit, delete, indent, move)
+- [x] Block tree editing (create, edit, delete, indent, move, reorder siblings)
 - [x] Collapse/expand blocks
 - [x] Undo/redo
 - [x] Full-text search across blocks
@@ -357,7 +360,7 @@ What's working now and what's next.
 ```bash
 git clone https://github.com/avelino/roam-tui
 cd roam-tui
-cargo test     # 551 tests
+cargo test     # 675 tests
 cargo run      # requires config with valid API token
 ```
 

--- a/docs/tui/README.md
+++ b/docs/tui/README.md
@@ -9,6 +9,7 @@
 - Edit blocks with optimistic updates (changes apply instantly, sync in background)
 - Undo/redo for text edits, block creation, deletion, and moves
 - Indent/dedent blocks with Tab/Shift+Tab
+- Reorder blocks among siblings with Alt+Up/Alt+Down
 - Block references `((uid))` resolve inline
 - Linked references section per day/page
 - Syntax highlighting for fenced code blocks (14 languages)

--- a/docs/tui/keybindings.md
+++ b/docs/tui/keybindings.md
@@ -27,6 +27,8 @@ preset = "vim"  # or "emacs" or "vscode"
 | Redo | `Ctrl+R` |
 | Indent | `Tab` |
 | Unindent | `Shift+Tab` |
+| Move block up | `Alt+Up` |
+| Move block down | `Alt+Down` |
 | Search | `/` |
 | Quick switcher | `Ctrl+P` |
 | Next day | `N` / `PageDown` |
@@ -67,6 +69,8 @@ preset = "vim"  # or "emacs" or "vscode"
 | Create block below | `Alt+Enter` |
 | Undo | `Ctrl+/` |
 | Redo | `Ctrl+Shift+/` |
+| Move block up | `Alt+Up` |
+| Move block down | `Alt+Down` |
 | Search | `Ctrl+S` |
 | Next day | `Alt+N` / `PageDown` |
 | Previous day | `Alt+P` / `PageUp` |
@@ -92,6 +96,8 @@ preset = "vim"  # or "emacs" or "vscode"
 | Create block below | `Ctrl+Enter` |
 | Undo | `Ctrl+Z` |
 | Redo | `Ctrl+Shift+Z` |
+| Move block up | `Alt+Shift+Up` |
+| Move block down | `Alt+Shift+Down` |
 | Search | `Ctrl+Shift+F` |
 | Quick switcher | `Ctrl+P` |
 | Next day | `Alt+Up` / `PageDown` |
@@ -128,4 +134,4 @@ Examples: `Ctrl+k`, `Alt+Enter`, `Shift+Left`, `Ctrl+Shift+Z`.
 
 ### Available actions
 
-`quit`, `move_up`, `move_down`, `cursor_left`, `cursor_right`, `collapse`, `expand`, `enter`, `exit`, `edit_block`, `create_block`, `indent`, `unindent`, `undo`, `redo`, `search`, `quick_switcher`, `next_day`, `prev_day`, `go_daily`, `toggle_sidebar`, `nav_back`, `nav_forward`, `export`, `select_up`, `select_down`, `help`
+`quit`, `move_up`, `move_down`, `cursor_left`, `cursor_right`, `collapse`, `expand`, `enter`, `exit`, `edit_block`, `create_block`, `indent`, `unindent`, `move_block_up`, `move_block_down`, `undo`, `redo`, `search`, `quick_switcher`, `next_day`, `prev_day`, `go_daily`, `toggle_sidebar`, `nav_back`, `nav_forward`, `export`, `select_up`, `select_down`, `help`

--- a/src/app/blocks.rs
+++ b/src/app/blocks.rs
@@ -316,6 +316,138 @@ fn find_parent_info_recursive(
     None
 }
 
+/// Move a block one position up among its siblings.
+///
+/// Swaps the block with the sibling immediately above it (same parent),
+/// swapping their `order` fields and their position in the `children` vec.
+/// Returns `Some((parent_uid, new_order, sibling_uid))` on success — where
+/// `sibling_uid` is the UID of the sibling the block was swapped with.
+/// Returns `None` when the block is already the first child of its parent
+/// or cannot be found.
+pub fn move_block_up_in_days(
+    days: &mut [DailyNote],
+    block_uid: &str,
+) -> Option<(String, i64, String)> {
+    for day in days.iter_mut() {
+        let day_uid = day.uid.clone();
+        if let Some(result) = try_swap_with_prev_sibling(&mut day.blocks, &day_uid, block_uid) {
+            return Some(result);
+        }
+    }
+    None
+}
+
+fn try_swap_with_prev_sibling(
+    blocks: &mut [Block],
+    parent_uid: &str,
+    block_uid: &str,
+) -> Option<(String, i64, String)> {
+    if let Some(pos) = blocks.iter().position(|b| b.uid == block_uid) {
+        if pos == 0 {
+            return None;
+        }
+        let sibling_uid = blocks[pos - 1].uid.clone();
+        let cur_order = blocks[pos].order;
+        let prev_order = blocks[pos - 1].order;
+        blocks[pos].order = prev_order;
+        blocks[pos - 1].order = cur_order;
+        blocks.swap(pos - 1, pos);
+        return Some((parent_uid.to_string(), prev_order, sibling_uid));
+    }
+    for block in blocks.iter_mut() {
+        let child_parent_uid = block.uid.clone();
+        if let Some(result) =
+            try_swap_with_prev_sibling(&mut block.children, &child_parent_uid, block_uid)
+        {
+            return Some(result);
+        }
+    }
+    None
+}
+
+/// Move a block one position down among its siblings.
+///
+/// Swaps the block with the sibling immediately below it (same parent),
+/// swapping their `order` fields and their position in the `children` vec.
+/// Returns `Some((parent_uid, new_order, sibling_uid))` on success — where
+/// `sibling_uid` is the UID of the sibling the block was swapped with.
+/// Returns `None` when the block is already the last child of its parent
+/// or cannot be found.
+pub fn move_block_down_in_days(
+    days: &mut [DailyNote],
+    block_uid: &str,
+) -> Option<(String, i64, String)> {
+    for day in days.iter_mut() {
+        let day_uid = day.uid.clone();
+        if let Some(result) = try_swap_with_next_sibling(&mut day.blocks, &day_uid, block_uid) {
+            return Some(result);
+        }
+    }
+    None
+}
+
+fn try_swap_with_next_sibling(
+    blocks: &mut [Block],
+    parent_uid: &str,
+    block_uid: &str,
+) -> Option<(String, i64, String)> {
+    if let Some(pos) = blocks.iter().position(|b| b.uid == block_uid) {
+        if pos + 1 >= blocks.len() {
+            return None;
+        }
+        let sibling_uid = blocks[pos + 1].uid.clone();
+        let cur_order = blocks[pos].order;
+        let next_order = blocks[pos + 1].order;
+        blocks[pos].order = next_order;
+        blocks[pos + 1].order = cur_order;
+        blocks.swap(pos, pos + 1);
+        return Some((parent_uid.to_string(), next_order, sibling_uid));
+    }
+    for block in blocks.iter_mut() {
+        let child_parent_uid = block.uid.clone();
+        if let Some(result) =
+            try_swap_with_next_sibling(&mut block.children, &child_parent_uid, block_uid)
+        {
+            return Some(result);
+        }
+    }
+    None
+}
+
+/// Swap two siblings (same parent) by UID, atomically.
+///
+/// Swaps both their position in the children vec AND their `order` fields,
+/// so the local tree remains consistent (orders sequential, no duplicates).
+/// Returns `true` if the swap succeeded, `false` if either uid was not found
+/// or they don't share a parent.
+pub fn swap_siblings_by_uid_in_days(days: &mut [DailyNote], uid_a: &str, uid_b: &str) -> bool {
+    for day in days.iter_mut() {
+        if try_swap_siblings_by_uid(&mut day.blocks, uid_a, uid_b) {
+            return true;
+        }
+    }
+    false
+}
+
+fn try_swap_siblings_by_uid(blocks: &mut [Block], uid_a: &str, uid_b: &str) -> bool {
+    let pos_a = blocks.iter().position(|b| b.uid == uid_a);
+    let pos_b = blocks.iter().position(|b| b.uid == uid_b);
+    if let (Some(a), Some(b)) = (pos_a, pos_b) {
+        let order_a = blocks[a].order;
+        let order_b = blocks[b].order;
+        blocks[a].order = order_b;
+        blocks[b].order = order_a;
+        blocks.swap(a, b);
+        return true;
+    }
+    for block in blocks.iter_mut() {
+        if try_swap_siblings_by_uid(&mut block.children, uid_a, uid_b) {
+            return true;
+        }
+    }
+    false
+}
+
 pub fn move_block_in_days(
     days: &mut [DailyNote],
     block_uid: &str,

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -126,6 +126,86 @@ fn handle_batch_dedent(state: &mut AppState) -> Option<WriteAction> {
     })
 }
 
+fn handle_move_block_up(state: &mut AppState) -> Option<WriteAction> {
+    if state
+        .resolve_linked_ref_item(state.selected_block)
+        .is_some()
+    {
+        return None;
+    }
+    let info =
+        blocks::resolve_block_at_index(&state.days, &state.linked_refs, state.selected_block)?;
+    let saved_selected = state.selected_block;
+    let block_old_order = info.order;
+    let (parent_uid, new_order, sibling_uid) =
+        blocks::move_block_up_in_days(&mut state.days, &info.block_uid)?;
+
+    state.redo_stack.clear();
+    if let Some(new_idx) =
+        blocks::find_block_index_by_uid(&state.days, &state.linked_refs, &info.block_uid)
+    {
+        state.selected_block = new_idx;
+        state.cursor_col = 0;
+    }
+    state.undo_stack.push(UndoEntry::SwapSiblings {
+        block_uid: info.block_uid.clone(),
+        sibling_uid,
+        parent_uid: parent_uid.clone(),
+        block_old_order,
+        selected_block: saved_selected,
+    });
+
+    Some(WriteAction::MoveBlock {
+        block: ApiBlockRef {
+            uid: info.block_uid,
+        },
+        location: BlockLocation {
+            parent_uid,
+            order: OrderValue::Index(new_order),
+        },
+    })
+}
+
+fn handle_move_block_down(state: &mut AppState) -> Option<WriteAction> {
+    if state
+        .resolve_linked_ref_item(state.selected_block)
+        .is_some()
+    {
+        return None;
+    }
+    let info =
+        blocks::resolve_block_at_index(&state.days, &state.linked_refs, state.selected_block)?;
+    let saved_selected = state.selected_block;
+    let block_old_order = info.order;
+    let (parent_uid, new_order, sibling_uid) =
+        blocks::move_block_down_in_days(&mut state.days, &info.block_uid)?;
+
+    state.redo_stack.clear();
+    if let Some(new_idx) =
+        blocks::find_block_index_by_uid(&state.days, &state.linked_refs, &info.block_uid)
+    {
+        state.selected_block = new_idx;
+        state.cursor_col = 0;
+    }
+    state.undo_stack.push(UndoEntry::SwapSiblings {
+        block_uid: info.block_uid.clone(),
+        sibling_uid,
+        parent_uid: parent_uid.clone(),
+        block_old_order,
+        selected_block: saved_selected,
+    });
+
+    Some(WriteAction::MoveBlock {
+        block: ApiBlockRef {
+            uid: info.block_uid,
+        },
+        location: BlockLocation {
+            parent_uid,
+            order: OrderValue::Index(new_order),
+        },
+    })
+}
+
 fn dispatch_load_request(
     request: LoadRequest,
     client: &RoamClient,
@@ -179,6 +259,14 @@ fn handle_normal_key(
             }
         } else if action == &Action::Unindent && state.selection.is_multi() {
             if let Some(write_action) = handle_batch_dedent(state) {
+                spawn_write(client, write_action, tx);
+            }
+        } else if action == &Action::MoveBlockUp {
+            if let Some(write_action) = handle_move_block_up(state) {
+                spawn_write(client, write_action, tx);
+            }
+        } else if action == &Action::MoveBlockDown {
+            if let Some(write_action) = handle_move_block_down(state) {
                 spawn_write(client, write_action, tx);
             }
         } else if let Some(req) = handle_action(state, action) {

--- a/src/app/state.rs
+++ b/src/app/state.rs
@@ -27,6 +27,13 @@ pub enum UndoEntry {
         old_order: i64,
         selected_block: usize,
     },
+    SwapSiblings {
+        block_uid: String,
+        sibling_uid: String,
+        parent_uid: String,
+        block_old_order: i64,
+        selected_block: usize,
+    },
     Batch(Vec<UndoEntry>),
 }
 

--- a/src/app/tests.rs
+++ b/src/app/tests.rs
@@ -3338,3 +3338,255 @@ fn creating_block_via_action_is_not_placeholder() {
         Some(WriteAction::CreateBlock { .. })
     ));
 }
+
+// --- move block up/down tests (issue #6) ---
+
+#[test]
+fn move_block_up_swaps_with_previous_sibling() {
+    let mut days = vec![make_daily_note(
+        2026,
+        2,
+        21,
+        vec![
+            make_block("b1", "First", 0),
+            make_block("b2", "Second", 1),
+            make_block("b3", "Third", 2),
+        ],
+    )];
+    let result = move_block_up_in_days(&mut days, "b2");
+    assert!(result.is_some());
+    let (parent_uid, order, sibling_uid) = result.unwrap();
+    assert_eq!(sibling_uid, "b1");
+    assert_eq!(parent_uid, "02-21-2026");
+    assert_eq!(order, 0);
+    // b2 is now at position 0, b1 at position 1
+    assert_eq!(days[0].blocks[0].uid, "b2");
+    assert_eq!(days[0].blocks[0].order, 0);
+    assert_eq!(days[0].blocks[1].uid, "b1");
+    assert_eq!(days[0].blocks[1].order, 1);
+    // b3 untouched
+    assert_eq!(days[0].blocks[2].uid, "b3");
+    assert_eq!(days[0].blocks[2].order, 2);
+}
+
+#[test]
+fn move_block_up_first_block_returns_none() {
+    let mut days = vec![make_daily_note(
+        2026,
+        2,
+        21,
+        vec![make_block("b1", "First", 0), make_block("b2", "Second", 1)],
+    )];
+    assert!(move_block_up_in_days(&mut days, "b1").is_none());
+    // unchanged
+    assert_eq!(days[0].blocks[0].uid, "b1");
+    assert_eq!(days[0].blocks[1].uid, "b2");
+}
+
+#[test]
+fn move_block_up_preserves_children() {
+    let block_with_kids = Block {
+        uid: "b2".into(),
+        string: "Parent".into(),
+        order: 1,
+        children: vec![make_block("c1", "Child", 0)],
+        open: true,
+        refs: vec![],
+    };
+    let mut days = vec![make_daily_note(
+        2026,
+        2,
+        21,
+        vec![make_block("b1", "First", 0), block_with_kids],
+    )];
+    move_block_up_in_days(&mut days, "b2");
+    assert_eq!(days[0].blocks[0].uid, "b2");
+    assert_eq!(days[0].blocks[0].children.len(), 1);
+    assert_eq!(days[0].blocks[0].children[0].uid, "c1");
+}
+
+#[test]
+fn move_block_up_nonexistent_block_returns_none() {
+    let mut days = vec![make_daily_note(
+        2026,
+        2,
+        21,
+        vec![make_block("b1", "First", 0)],
+    )];
+    assert!(move_block_up_in_days(&mut days, "nope").is_none());
+}
+
+#[test]
+fn move_block_up_nested_block() {
+    let parent = Block {
+        uid: "p".into(),
+        string: "Parent".into(),
+        order: 0,
+        children: vec![
+            make_block("c1", "Child 1", 0),
+            make_block("c2", "Child 2", 1),
+        ],
+        open: true,
+        refs: vec![],
+    };
+    let mut days = vec![make_daily_note(2026, 2, 21, vec![parent])];
+    let result = move_block_up_in_days(&mut days, "c2");
+    assert!(result.is_some());
+    let (parent_uid, _, sibling_uid) = result.unwrap();
+    assert_eq!(sibling_uid, "c1");
+    assert_eq!(parent_uid, "p");
+    assert_eq!(days[0].blocks[0].children[0].uid, "c2");
+    assert_eq!(days[0].blocks[0].children[1].uid, "c1");
+}
+
+#[test]
+fn move_block_down_swaps_with_next_sibling() {
+    let mut days = vec![make_daily_note(
+        2026,
+        2,
+        21,
+        vec![
+            make_block("b1", "First", 0),
+            make_block("b2", "Second", 1),
+            make_block("b3", "Third", 2),
+        ],
+    )];
+    let result = move_block_down_in_days(&mut days, "b2");
+    assert!(result.is_some());
+    let (parent_uid, order, sibling_uid) = result.unwrap();
+    assert_eq!(sibling_uid, "b3");
+    assert_eq!(parent_uid, "02-21-2026");
+    assert_eq!(order, 2);
+    assert_eq!(days[0].blocks[0].uid, "b1");
+    assert_eq!(days[0].blocks[0].order, 0);
+    assert_eq!(days[0].blocks[1].uid, "b3");
+    assert_eq!(days[0].blocks[1].order, 1);
+    assert_eq!(days[0].blocks[2].uid, "b2");
+    assert_eq!(days[0].blocks[2].order, 2);
+}
+
+#[test]
+fn move_block_down_last_block_returns_none() {
+    let mut days = vec![make_daily_note(
+        2026,
+        2,
+        21,
+        vec![make_block("b1", "First", 0), make_block("b2", "Second", 1)],
+    )];
+    assert!(move_block_down_in_days(&mut days, "b2").is_none());
+    assert_eq!(days[0].blocks[0].uid, "b1");
+    assert_eq!(days[0].blocks[1].uid, "b2");
+}
+
+#[test]
+fn move_block_down_nested_block() {
+    let parent = Block {
+        uid: "p".into(),
+        string: "Parent".into(),
+        order: 0,
+        children: vec![
+            make_block("c1", "Child 1", 0),
+            make_block("c2", "Child 2", 1),
+        ],
+        open: true,
+        refs: vec![],
+    };
+    let mut days = vec![make_daily_note(2026, 2, 21, vec![parent])];
+    let result = move_block_down_in_days(&mut days, "c1");
+    assert!(result.is_some());
+    let (parent_uid, _, sibling_uid) = result.unwrap();
+    assert_eq!(sibling_uid, "c2");
+    assert_eq!(parent_uid, "p");
+    assert_eq!(days[0].blocks[0].children[0].uid, "c2");
+    assert_eq!(days[0].blocks[0].children[1].uid, "c1");
+}
+
+#[test]
+fn move_block_up_handler_emits_write_action_and_pushes_undo() {
+    let mut state = test_state();
+    state.selected_block = 1; // b2
+    let action = super::handle_move_block_up(&mut state);
+    assert!(action.is_some());
+    match action.unwrap() {
+        WriteAction::MoveBlock { block, location } => {
+            assert_eq!(block.uid, "b2");
+            assert_eq!(location.parent_uid, "02-21-2026");
+        }
+        _ => panic!("Expected MoveBlock"),
+    }
+    // Selection follows the moved block (now at index 0)
+    assert_eq!(state.selected_block, 0);
+    // Undo entry pushed
+    assert_eq!(state.undo_stack.len(), 1);
+}
+
+#[test]
+fn move_block_down_handler_emits_write_action_and_pushes_undo() {
+    let mut state = test_state();
+    state.selected_block = 1; // b2 (middle of three)
+    let action = super::handle_move_block_down(&mut state);
+    assert!(action.is_some());
+    match action.unwrap() {
+        WriteAction::MoveBlock { block, location } => {
+            assert_eq!(block.uid, "b2");
+            assert_eq!(location.parent_uid, "02-21-2026");
+        }
+        _ => panic!("Expected MoveBlock"),
+    }
+    // Selection follows the moved block (now at index 2)
+    assert_eq!(state.selected_block, 2);
+    assert_eq!(state.undo_stack.len(), 1);
+}
+
+#[test]
+fn move_block_up_handler_at_boundary_is_noop() {
+    let mut state = test_state();
+    state.selected_block = 0; // b1, first
+    let action = super::handle_move_block_up(&mut state);
+    assert!(action.is_none());
+    // No undo pushed
+    assert!(state.undo_stack.is_empty());
+    // Selection unchanged
+    assert_eq!(state.selected_block, 0);
+}
+
+#[test]
+fn move_block_down_handler_at_boundary_is_noop() {
+    let mut state = test_state();
+    state.selected_block = 2; // b3, last
+    let action = super::handle_move_block_down(&mut state);
+    assert!(action.is_none());
+    assert!(state.undo_stack.is_empty());
+    assert_eq!(state.selected_block, 2);
+}
+
+#[test]
+fn move_block_undo_restores_original_order() {
+    let mut state = test_state();
+    state.selected_block = 1; // b2
+    super::handle_move_block_up(&mut state).expect("should move");
+    // After move: b2, b1, b3
+    assert_eq!(state.days[0].blocks[0].uid, "b2");
+
+    // Undo restores: b1, b2, b3
+    let undo_action = apply_undo(&mut state);
+    assert!(matches!(undo_action, Some(WriteAction::MoveBlock { .. })));
+    assert_eq!(state.days[0].blocks[0].uid, "b1");
+    assert_eq!(state.days[0].blocks[1].uid, "b2");
+    assert_eq!(state.days[0].blocks[2].uid, "b3");
+    // Selection restored
+    assert_eq!(state.selected_block, 1);
+}
+
+#[test]
+fn move_block_up_clears_redo_stack() {
+    let mut state = test_state();
+    state.selected_block = 1;
+    // Seed a redo entry to verify it's cleared
+    state.redo_stack.push(UndoEntry::TextEdit {
+        block_uid: "x".into(),
+        old_text: "y".into(),
+    });
+    super::handle_move_block_up(&mut state);
+    assert!(state.redo_stack.is_empty());
+}

--- a/src/app/undo.rs
+++ b/src/app/undo.rs
@@ -2,7 +2,8 @@ use crate::api::types::{BlockLocation, BlockRef, BlockUpdate, NewBlock, OrderVal
 
 use super::blocks::{
     find_block_in_days, find_block_parent_info, insert_block_in_days, move_block_in_days,
-    remove_block_from_days, resolve_block_at_index, update_block_text_in_days,
+    remove_block_from_days, resolve_block_at_index, swap_siblings_by_uid_in_days,
+    update_block_text_in_days,
 };
 use super::state::{AppState, UndoEntry};
 
@@ -157,6 +158,42 @@ fn apply_undo_entry(state: &mut AppState, entry: UndoEntry) -> (UndoEntry, Write
                 location: BlockLocation {
                     parent_uid: old_parent_uid,
                     order: OrderValue::Index(old_order),
+                },
+            };
+            (redo, write)
+        }
+        UndoEntry::SwapSiblings {
+            block_uid,
+            sibling_uid,
+            parent_uid,
+            block_old_order,
+            selected_block,
+        } => {
+            let current_selected = state.selected_block;
+            // Swap is involutive — applying it again restores the previous state.
+            swap_siblings_by_uid_in_days(&mut state.days, &block_uid, &sibling_uid);
+            state.selected_block = selected_block;
+            state.cursor_col = 0;
+
+            // After the inverse swap, `block_uid` is back at `block_old_order`.
+            // The redo entry repeats this swap, restoring the post-move state.
+            // The current (pre-swap) order of the block is the sibling's old order,
+            // which after the inverse swap is now held by the sibling.
+            let redo_block_old_order = find_block_parent_info(&state.days, &block_uid)
+                .map(|(_, order)| order)
+                .unwrap_or(block_old_order);
+            let redo = UndoEntry::SwapSiblings {
+                block_uid: block_uid.clone(),
+                sibling_uid,
+                parent_uid: parent_uid.clone(),
+                block_old_order: redo_block_old_order,
+                selected_block: current_selected,
+            };
+            let write = WriteAction::MoveBlock {
+                block: BlockRef { uid: block_uid },
+                location: BlockLocation {
+                    parent_uid,
+                    order: OrderValue::Index(block_old_order),
                 },
             };
             (redo, write)

--- a/src/keys/mod.rs
+++ b/src/keys/mod.rs
@@ -78,6 +78,8 @@ impl KeybindingMap {
             Action::QuickSwitcher,
             Action::Indent,
             Action::Unindent,
+            Action::MoveBlockUp,
+            Action::MoveBlockDown,
             Action::Undo,
             Action::Redo,
             Action::NavBack,

--- a/src/keys/preset.rs
+++ b/src/keys/preset.rs
@@ -20,6 +20,8 @@ pub enum Action {
     QuickSwitcher,
     Indent,
     Unindent,
+    MoveBlockUp,
+    MoveBlockDown,
     EditBlock,
     CreateBlock,
     Undo,
@@ -52,6 +54,8 @@ impl Action {
             "quick_switcher" => Some(Self::QuickSwitcher),
             "indent" => Some(Self::Indent),
             "unindent" => Some(Self::Unindent),
+            "move_block_up" => Some(Self::MoveBlockUp),
+            "move_block_down" => Some(Self::MoveBlockDown),
             "edit_block" => Some(Self::EditBlock),
             "create_block" => Some(Self::CreateBlock),
             "undo" => Some(Self::Undo),
@@ -85,6 +89,8 @@ impl Action {
             Self::QuickSwitcher => "switcher",
             Self::Indent => "indent",
             Self::Unindent => "unindent",
+            Self::MoveBlockUp => "move ↑",
+            Self::MoveBlockDown => "move ↓",
             Self::EditBlock => "edit",
             Self::CreateBlock => "new block",
             Self::Undo => "undo",
@@ -120,6 +126,10 @@ fn ctrl_shift(code: KeyCode) -> KeyEvent {
     KeyEvent::new(code, KeyModifiers::CONTROL | KeyModifiers::SHIFT)
 }
 
+fn alt_shift(code: KeyCode) -> KeyEvent {
+    KeyEvent::new(code, KeyModifiers::ALT | KeyModifiers::SHIFT)
+}
+
 pub fn vim_preset() -> HashMap<KeyEvent, Action> {
     let mut m = HashMap::new();
     m.insert(key(KeyCode::Char('k')), Action::MoveUp);
@@ -137,6 +147,8 @@ pub fn vim_preset() -> HashMap<KeyEvent, Action> {
     m.insert(ctrl(KeyCode::Char('k')), Action::QuickSwitcher);
     m.insert(key(KeyCode::Tab), Action::Indent);
     m.insert(shift(KeyCode::BackTab), Action::Unindent);
+    m.insert(alt(KeyCode::Up), Action::MoveBlockUp);
+    m.insert(alt(KeyCode::Down), Action::MoveBlockDown);
     m.insert(key(KeyCode::Char('i')), Action::EditBlock);
     m.insert(key(KeyCode::Char('o')), Action::CreateBlock);
     m.insert(key(KeyCode::Char('u')), Action::Undo);
@@ -174,6 +186,8 @@ pub fn emacs_preset() -> HashMap<KeyEvent, Action> {
     m.insert(ctrl(KeyCode::Char('h')), Action::Help);
     m.insert(key(KeyCode::Tab), Action::Indent);
     m.insert(shift(KeyCode::BackTab), Action::Unindent);
+    m.insert(alt(KeyCode::Up), Action::MoveBlockUp);
+    m.insert(alt(KeyCode::Down), Action::MoveBlockDown);
     m.insert(key(KeyCode::Enter), Action::EditBlock);
     m.insert(alt(KeyCode::Enter), Action::CreateBlock);
     m.insert(ctrl(KeyCode::Char('/')), Action::Undo);
@@ -215,6 +229,8 @@ pub fn vscode_preset() -> HashMap<KeyEvent, Action> {
     m.insert(ctrl(KeyCode::Char('d')), Action::GoDaily);
     m.insert(key(KeyCode::Tab), Action::Indent);
     m.insert(shift(KeyCode::BackTab), Action::Unindent);
+    m.insert(alt_shift(KeyCode::Up), Action::MoveBlockUp);
+    m.insert(alt_shift(KeyCode::Down), Action::MoveBlockDown);
     m.insert(key(KeyCode::Enter), Action::EditBlock);
     m.insert(ctrl(KeyCode::Enter), Action::CreateBlock);
     m.insert(ctrl(KeyCode::Char('z')), Action::Undo);


### PR DESCRIPTION
Roam web reorders siblings with Cmd+Shift+arrows. The TUI had no way to move a block without changing its parent via indent/dedent

New MoveBlockUp/MoveBlockDown actions swap a block with its prev/next sibling (vec position + order field). Bound to Alt+Up/Down in vim and emacs, Alt+Shift+Up/Down in vscode to avoid colliding with the existing NextDay/PrevDay binding. Undo uses a new SwapSiblings variant since reverting a swap via the existing MoveBlock entry left duplicate order fields on local state.

fixed: #6